### PR TITLE
Add no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ readme = "readme.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-brotli = { version = "3.3.3", default-features = false, features = ["std"] }
-bytes = "1.1.0"
-four-cc = "0.2.0"
+brotli = { version = "3.3.3", default-features = false }
+bytes = { version = "1.1.0", default-features = false }
+four-cc = { version = "0.2.0", default-features = false }
 safer-bytes = "0.2.0"
 thiserror = "1.0.30"
 bitvec = "1.0.0"
@@ -22,3 +22,7 @@ bitvec = "1.0.0"
 [dev-dependencies]
 clap = { version = "3.1.6", features = ["derive"] }
 ttf-parser = "0.15.0"
+
+[features]
+default = ["std"]
+std = ["brotli/std", "bytes/std", "four-cc/std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ readme = "readme.md"
 
 [dependencies]
 brotli = { version = "3.3.3", default-features = false }
-bytes = { version = "1.1.0", default-features = false }
-four-cc = { version = "0.2.0", default-features = false }
+bytes = { version = "1.7.1", default-features = false }
+four-cc = { version = "0.4.0", default-features = false }
 safer-bytes = "0.2.0"
 thiserror = "1.0.30"
 bitvec = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,16 +12,17 @@ readme = "readme.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-brotli = { version = "6.0.0", default-features = false }
 bytes = { version = "1.7.1", default-features = false }
 four-cc = { version = "0.4.0", default-features = false }
 safer-bytes = "0.2.0"
 thiserror = "1.0.30"
 bitvec = "1.0.0"
+brotli = { version = "6.0.0", default-features = false }
+alloc-no-stdlib = "2.0.4"
 
 [dev-dependencies]
-clap = { version = "3.1.6", features = ["derive"] }
-ttf-parser = "0.15.0"
+clap = { version = "4.5.13", features = ["derive"] }
+ttf-parser = "0.24.0"
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "readme.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-brotli = { version = "3.3.3", default-features = false }
+brotli = { version = "6.0.0", default-features = false }
 bytes = { version = "1.7.1", default-features = false }
 four-cc = { version = "0.4.0", default-features = false }
 safer-bytes = "0.2.0"


### PR DESCRIPTION
This PR allow users to compile to `no_std` environment.

- Allow disable `std` feature for `four-cc` and `bytes` crates
- Use `BrotliDecompressCustomIo` to decompress input manually by `StackAllocator` from `alloc-no-stdlib` crate