### PR TITLE
Fix woff2 error conversion issues for modern Rust compatibility

### DIFF
--- a/src/woff2/collection_directory.rs
+++ b/src/woff2/collection_directory.rs
@@ -4,7 +4,7 @@ use bytes::{Buf, BufMut};
 use four_cc::FourCC;
 use thiserror::Error;
 
-use crate::buffer_util::{BufExt, SafeBuf, TruncatedError};
+use crate::buffer_util::{BufExt, TruncatedError};
 use crate::ttf_header::{TableDirectory, TableRecord};
 
 #[derive(Debug, Error)]
@@ -55,7 +55,10 @@ impl CollectionHeader {
         buf: &mut impl Buf,
         total_num_tables: u16,
     ) -> Result<Self, CollectionHeaderError> {
-        let version = buf.try_get_u32()?.try_into()?;
+        let version = buf
+            .try_get_u32()
+            .map_err(|_| CollectionHeaderError::Truncated)?
+            .try_into()?;
         let num_fonts = buf.try_get_255_u16()?;
         let fonts = (0..num_fonts)
             .map(|_| {

--- a/src/woff2/table_directory.rs
+++ b/src/woff2/table_directory.rs
@@ -5,7 +5,7 @@ use four_cc::FourCC;
 use thiserror::Error;
 
 use crate::{
-    buffer_util::{pad_to_multiple_of_four, Base128Error, BufExt, SafeBuf, TruncatedError},
+    buffer_util::{pad_to_multiple_of_four, Base128Error, BufExt, TruncatedError},
     checksum::{calculate_checksum, set_checksum_adjustment, ChecksumError},
     glyf_decoder::{decode_glyf_table, GlyfDecoderError},
     ttf_header::TableRecord,
@@ -188,7 +188,9 @@ struct PartialTableDirectoryEntry {
 
 impl PartialTableDirectoryEntry {
     fn from_buf(buffer: &mut impl Buf) -> Result<Self, TableDirectoryError> {
-        let flags = buffer.try_get_u8()?;
+        let flags = buffer
+            .try_get_u8()
+            .map_err(|_| TableDirectoryError::Truncated)?;
         let preprocessing_transformation_version = flags & 0xC0;
         let table_ref = flags & 0x3f;
         let tag = if table_ref == 0x3f {


### PR DESCRIPTION
- Implemented explicit error type conversions using map_err() where the ? operator was failing
- Fixed incompatibility between TryGetError and various error types (Base128Error, Truncated, etc.)
- Resolved ambiguous try_get_u8() method calls
- Addressed error handling in collection_directory.rs and table_directory.rs

These changes allow the woff2 crate to compile with current Rust toolchains and dependencies.